### PR TITLE
Prevent confusion by replacing outdated repo link

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -43,7 +43,7 @@
     <div class="actions__icon --native" aria-hidden="true"></div>
     Intercept with a native view
   </a>
-  <a class="actions__item" href="https://github.com/turbolinks/turbolinks" target="_blank">
+  <a class="actions__item" href="https://turbo.hotwired.dev" target="_blank">
     <div class="actions__icon --external" aria-hidden="true"></div>
     Follow an external link
   </a>


### PR DESCRIPTION
The example code for "Follow an external link" presented [turbolinks/turbolinks](https://github.com/turbolinks/turbolinks). It may be too minor to open a PR for, but some link to the Hotwire world is probably less confusing to people new to it, than an archived repo on GitHub.

Thanks for making Hotwire! 👋🏻 