### PR TITLE
Use Turbo 8 and morphing

### DIFF
--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -3,6 +3,8 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+    <meta name="turbo-refresh-method" content="morph">
+    <meta name="turbo-refresh-scroll" content="preserve">
 
     <title><%= title %></title>
 

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -18,7 +18,7 @@
     <script type="importmap">
       {
         "imports": {
-          "@hotwired/turbo": "https://cdn.jsdelivr.net/npm/@hotwired/turbo@7.3.0/+esm",
+          "@hotwired/turbo": "https://cdn.jsdelivr.net/npm/@hotwired/turbo@8.0.2/+esm",
           "@hotwired/stimulus": "https://cdn.jsdelivr.net/npm/@hotwired/stimulus@3.2.2/+esm",
           "@hotwired/strada": "https://cdn.jsdelivr.net/npm/@hotwired/strada@1.0.0-beta1/+esm"
         }

--- a/views/one.ejs
+++ b/views/one.ejs
@@ -5,3 +5,13 @@
 <p><a href="/two" class="button@native space --bottom-flush">Advance to another webpage</a></p>
 <p>And this next one does a <em>replace</em> instead:</p>
 <p><a href="/two?action=replace" class="button@native space --buttom-flush" data-turbo-action="replace">Replace with another webpage</a></p>
+<p>And this next one replaces to the current page (morphs):</p>
+<p><a href="/one" class="button@native space --buttom-flush" data-turbo-action="replace">Refresh</a></p>
+<p>And this one programatically refreshes:</p>
+<p><a id="refresh" class="button@native space --buttom-flush" data-turbo-action="replace">Refresh programatically</a></p>
+
+<script>
+  document.getElementById("refresh").addEventListener("click", () => {
+    Turbo.session.refresh(document.baseURI)
+  })
+</script>


### PR DESCRIPTION
This PR changes Turbo to the recently released version 8 and adds a demo of page refreshes with morphing.

Hopefully this will make it easier to address the Turbo Native morph/refresh issue mentioned in https://github.com/hotwired/turbo-ios/issues/136
 