### PR TITLE
Add es module shims to layout

### DIFF
--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -16,6 +16,8 @@
       <link rel="stylesheet" href="/styles/native.css">
       <link rel="stylesheet" href="/styles/bridge.css">
     <% } %>
+      
+      <script async src="https://ga.jspm.io/npm:es-module-shims@1.10.0/dist/es-module-shims.js"></script>
 
     <script type="importmap">
       {


### PR DESCRIPTION
Add the es module shims to the layout.ejs.

Otherwise the demo fails mysteriously on older  devices. (iOS before 16.4, for a start.)